### PR TITLE
Fix CodePreview being shown when mouse is outside of stack-view

### DIFF
--- a/package/Editor/Patches/Patch_Console.cs
+++ b/package/Editor/Patches/Patch_Console.cs
@@ -49,6 +49,32 @@ namespace Needle.Demystify
 			private set => _consoleWindow = value;
 		}
 
+		private static Type SplitterStateType = typeof(Editor).Assembly.GetType("UnityEditor.SplitterState");
+		private static FieldInfo SplitterState = ConsoleWindowType.GetField("spl", BindingFlags.NonPublic | BindingFlags.Instance);
+		private static FieldInfo SplitterRealSizes = SplitterStateType.GetField("realSizes", BindingFlags.Public | BindingFlags.Instance);
+		private static FieldInfo TextScroll = ConsoleWindowType.GetField("m_TextScroll", BindingFlags.NonPublic | BindingFlags.Instance);
+
+		public static Rect GetStackScrollViewRect()
+		{
+			var rect = ConsoleWindow.position;
+
+			var splitState = SplitterState.GetValue(ConsoleWindow);
+			var splitRealSizes = (float[])SplitterRealSizes.GetValue(splitState);
+
+			var stackViewSize = splitRealSizes[1];
+
+			rect.x = 0;
+			rect.y = GetStackTextScroll().y;
+			rect.height = stackViewSize;
+			
+			return rect;
+		}
+		
+		private static Vector2 GetStackTextScroll()
+		{
+			return (Vector2)TextScroll.GetValue(ConsoleWindow);
+		}
+		
 		private class ConsoleDrawingEvent : EditorPatch
 		{
 			protected override Task OnGetTargetMethods(List<MethodBase> targetMethods)

--- a/package/Editor/Patches/Patch_EditorGUI.cs
+++ b/package/Editor/Patches/Patch_EditorGUI.cs
@@ -65,8 +65,10 @@ namespace Needle.Demystify
 			}
 			
 			if (evt == null || (evt.type != EventType.Repaint && evt.type != EventType.MouseMove)) return;
-			if (!position.Contains(mouse)) return;
+			
+			var stackViewRect = Patch_Console.GetStackScrollViewRect();
 
+			if (!stackViewRect.Contains(mouse)) return;
 
 			var prevSelection = editor.selectIndex;
 			var prevSelectionEnd = editor.cursorIndex;


### PR DESCRIPTION
**The issue:**
When you hover over hyperlinks that are hidden by scroll view - the CodePreview shows up.

**The fix:**
Using local stack-view rect instead of TextEditor position